### PR TITLE
Update usage instructions after major version

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,7 +39,9 @@ Node-libxml has been thought differently than [libxmljs](https://github.com/libx
 ## Use
 
 ```javascript
-  const Libxml = require('node-libxml');
+  const { Libxml } = require('node-libxml');
+  // import { Libxml } from "node-libxml"
+  
   let libxml = new Libxml();
 
   let xmlIsWellformed = libxml.loadXml('path/to/xml');


### PR DESCRIPTION
Hi 👋

We've been using `node-libxml` in our project, ResearchEquals, for a while. With the latest major release, our build no longer succeeded. Specifically we got the error based on previous import statements that `Libxml has no constructor`.

I was hoping to find the relevant documentation here, and could not. After some fiddling, I figured out a way to fix it, and figured I would submit a PR for you to consider.

Thanks for the library and the work you put in 🙌 