### PR TITLE
docs: revisited `Readme.md`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,34 +1,34 @@
 # Node-LibXML
 
-#### For old node.js versions please use verison < 4.0.0 Already for old LTS node (4,6,8) `npm install node-libxml@3.2.5`;
+#### For old node.js versions please use version < 4.0.0 Already for old LTS node (4,6,8) `npm install node-libxml@3.2.5`;
 
-#### For new node.js versions (10,12,14,16,18,20) we are using n-api so please install `npm install node-libxml@5.0.0`, its compatible with arm proc too for version >= 16 (you wil notice a free memoery message when using free memory function after node >16) 🙂
+#### For new node.js versions (10,12,14,16,18,20) we are using n-api so please install `npm install node-libxml@5.0.0`, its compatible with arm proc too for version >= 16 (you wil notice a free memory message when using free memory function after node >16) 🙂
 
-Node-Libxml is a LibXML2 Node.js Wrapper
+_Node-Libxml_ is a _[libxml2]_ Node.js Wrapper
 
 It can perform:
 
-- Wellformed check & rerror report
+- Well-formed check & error report
 - Validity against DTD/XSD(Schema) check,
-- Get doctype informations (about dtd)
-- GetXpath Values
+- Get doctype information (about DTD)
+- Get XPath Values
 - Load XMl from string or file path
 
 ## Requirements:
 
-Node-Libxml has nos any dependencies, it's fully bundled, so you can just use it as it comes :)
+Node-Libxml has no dependencies; it's fully bundled, so you can just use it as it comes :)
 
-Works on : Linux, Osx & Windows (no 32bits, **just 64 bits**)
+Works on: Linux, macOS & Windows (no 32bits, **just 64 bits**)
 
 ## Why use it
 
-Node-libxml has been thought differently than [libxmljs](https://github.com/libxmljs/libxmljs); whereas libxmljs can be use in commun uses, you can use node-libxml if:
+_Node-LibXML_ has been thought differently than _[libxmljs]_; whereas _libxmljs_ can be use in common uses, you can use _node-libxml_ if:
 
-- You wan to validate against DTD (libxmljs can't)
-- You want a silent program if xml is not wellformed (node-libxml returns wellformed error in object; libxmljs throws)
-- You want to do xml processing in parallel forks
-- You want to load XML from file path OR string
-- You want to validate against DTD / schema on multiple documents with just ONE dtd/schema loaded in memory (libxmljs loads it on each validation request), so it's clearly by far fastest!
+- You want to validate against DTD (_libxmljs_ can't)
+- You want a silent program if XML is not well-formed (_node-libxml_ returns well-formed error in object; _libxmljs_ throws)
+- You want to do XML processing in parallel forks
+- You want to load XML from file path *or* string
+- You want to validate against DTD / schema on multiple documents with just *one* DTD/schema loaded in memory (_libxmljs_ loads it on each validation request), so it's clearly by far fastest!
 
 ## Install
 
@@ -62,99 +62,100 @@ Node-libxml has been thought differently than [libxmljs](https://github.com/libx
   //... & all xpath could do I think
 ```
 
-check [tests](./test/libxml-test.js) for more examples
+See our [tests](tests/libxml-test.spec.ts) for more examples.
 
 ## API
 
 ### Loading functions
 
-##### loadXml(string)
+##### `loadXml(string)`
 
-A function of libxml to load the XML file
-`TAKE a path & RETURN true if wellformed | false if not`
-`SET a an array 'wellformedErrors' in libxml element containing wellformed errors`
+A function of _libxml2_ to load the XML file
+* TAKE a path & RETURN `true` if well-formed | `false` if not
+* SET an array `wellformedErrors` in _libxml2_ element containing well-formed errors
 
-##### loadXmlFromString(string)
+##### `loadXmlFromString(string)`
 
-A function of libxml to create the xml Dom from a string
-`TAKE a string containing xml & RETURN true if wellformed | false if not`
-`SET a an array 'wellformedErrors' in libxml element containing wellformed errors`
+A function of _libxml2_ to create the XML DOM from a string
+* TAKE a string containing XML & RETURN `true` if well-formed | `false` if not
+* SET an array `wellformedErrors` in _libxml2_ element containing well-formed errors
 
-##### loadDtds(array)
+##### `loadDtds(array)`
 
-A function of libxml to load the DTDs files
-`TAKE an array of path of & RETURN nothing`
-`SET a an array 'dtdsLoadedErrors' in libxml element IF error happend on loading dtd(s)`
+A function of _libxml2_ to load the DTD(s) file(s)
+* TAKE an array of path of & RETURN nothing
+* SET an array `dtdsLoadedErrors` in _libxml2_ element IF error happened on loading DTD(s)
 
-##### loadSchemas(array)
+##### `loadSchemas(array)`
 
-A function of libxml to load the XSDs files
-`TAKE an array of path of & RETURN nothing`
-`SET a an array 'schemasLoadedErrors' in libxml element IF error happend on loading xsd(s)`
-[ex](./test/libxml-test.js#L157)
+A function of _libxml2_ to load the XSD(s) file(s)  
+[ex](tests/libxml-test.spec.ts#L206)
+* TAKE an array of path of & RETURN nothing
+* SET an array `schemasLoadedErrors` in _libxml2_ element IF error happened on loading XSD(s)
+
 
 ### Validating functions
 
-##### validateAgainstDtd()
+##### `validateAgainstDtd()`
 
-A function of libxml to validate against the previously loaded DTD(s)
-`TAKE nothing & RETURN a string which is the name of the first dtd which has validated`
-`RETURN false if no dtd(s) have validate the xml`
-`RETURN null if no any dtd have been corectly loaded`
-`SET a an array 'validationDtdErrors' in libxml element if no dtd has validate`
+A function of _libxml2_ to validate against the previously loaded DTD(s)
+* TAKE nothing & RETURN a string which is the name of the first DTD which has validated
+* RETURN `false` if no DTD(s) have validated the XML
+* RETURN `null` if not any DTD have been correctly loaded
+* SET an array `validationDtdErrors` in _libxml2_ element if no DTD has validate
 
-##### validateAgainstSchemas()
+##### `validateAgainstSchemas()`
 
-A function of libxml to validate against the previously loaded DTD(s)
-`TAKE nothing & RETURN a string which is the name of the first dtd which has validated`
-`RETURN false if no dtd(s) have validate the xml`
-`RETURN null if no any schema have been corectly loaded`
-`SET a an array 'validationDtdErrors' in libxml element if no dtd has validate`
+A function of _libxml2_ to validate against the previously loaded DTD(s)
+* TAKE nothing & RETURN a string which is the name of the first DTD which has validated
+* RETURN `false` if no DTD(s) have validated the XML
+* RETURN `null` if no any schema have been correctly loaded
+* SET an array `validationDtdErrors` in _libxml2_ element if no DTD has validated
 
-### Get informations of the the XML
+### Get information of the XML
 
-#### getDtd()
+#### `getDtd()`
 
-A function of libxml to evaluate the xpath on the previously loaded XML
-`TAKE nothin & RETURN an object containing name,externalId & systemId`
+A function of _libxml2_ to evaluate the xpath on the previously loaded XML
+* TAKE nothing & RETURN an object containing name, externalId & systemId
 
-#### xpathSelect(string)
+#### `xpathSelect(string)`
 
-A function of libxml to evaluate the xpath on the previously loaded XML
-`TAKE string & RETURN value depending on what you asked (number, boolean..)`
-`RETURN null if no match`
-[ex](./test/libxml-test.js#L69)
+A function of _libxml2_ to evaluate the xpath on the previously loaded XML  
+[ex](tests/libxml-test.spec.ts#L109)
+* TAKE string & RETURN value depending on what you asked (number, boolean,...)
+* RETURN `null` if no match
 
 ### Memory management
 
-Use those functions when you have finished jobs of elements, or before overwrite them.
-[ex](./test/libxml-test.js#100)
+Use those functions when you have finished jobs of elements, or before overwrite them.  
+[ex](tests/libxml-test.spec.tss#138)
 
-##### freeXml()
+##### `freeXml()`
 
-A function of libxml to free XML memory file
-`TAKE nothing & RETURN nothin`
-`FREE memory & clear 'wellformedErrors' property on libxml instance`
+A function of _libxml2_ to free XML memory file
+* TAKE nothing & RETURN nothing
+* FREE memory & clear `wellformedErrors` property on _libxml2_ instance
 
-##### freeDtds()
+##### `freeDtds()`
 
-A function of libxml to free all the DTD in memory
-`TAKE nothing & RETURN nothin`
-`FREE memory & clear 'dtdsLoadedErrors' property on libxml instance`
-`FREE memory & clear 'validationDtdErrors' property on libxml instance`
+A function of _libxml2_ to free all the DTD(s) in memory
+* TAKE nothing & RETURN nothing
+* FREE memory & clear `dtdsLoadedErrors` property on _libxml2_ instance
+* FREE memory & clear `validationDtdErrors` property on _libxml2_ instance
 
-##### freeSchemas()
+##### `freeSchemas()`
 
-A function of libxml to free all the Schema in memory
-`TAKE nothing & RETURN nothin`
-`FREE memory & clear 'schemasLoadedErrors' property on libxml instance`
-`FREE memory & clear 'validationSchemaErrors' property on libxml instance`
+A function of _libxml2_ to free all the Schema in memory
+* TAKE nothing & RETURN nothing
+* FREE memory & clear 'schemasLoadedErrors' property on _libxml2_ instance
+* FREE memory & clear 'validationSchemaErrors' property on _libxml2_ instance
 
-##### clearAll()
+##### `clearAll()`
 
-A function of libxml to free all the memory taken by libxml2
-`TAKE nothing & RETURN nothin`
-free all memory in all instance in all fork using by libxml.
+A function of _libxml2_ to free all the memory taken by _libxml2_
+* TAKE nothing & RETURN nothing
+* free all memory in all instance in all fork using by _libxml2_
 
 ## Contribute
 
@@ -167,3 +168,7 @@ free all memory in all instance in all fork using by libxml.
 ## Important notes
 
 Travis & appveyor cannot be used anymore with n-api because auto-publish from node-pre-gyp-github not working anymore + we have now n release for one node version
+
+
+[libxml2]: https://gitlab.gnome.org/GNOME/libxml2
+[libxmljs]: https://github.com/libxmljs/libxmljs


### PR DESCRIPTION
- fixed typos and misspellings
- streamlined OS: `Osx` is officially called `macOS`
- streamlined `XML` -> uppercase, always
- streamlined `DTD` -> uppercase, always
- streamlined `XSD` -> uppercase, always
- fixed links to examples
- streamlined link to _libxmljs_
- added link to _libxml2_
- made return types as code-blocks (added back-ticks `` ` ``)
- made clear whether _libxml_ meant a js library, or the `libxml2`
- Emphasized proper nouns by surrounding with underscore(`_`)
- made function names/calls in headlines as code blocks 

rendered preview: https://github.com/jkowalleck/fork_node-libxml/blob/docs/revidit-readme-1/Readme.md 
